### PR TITLE
Fix crew name/number

### DIFF
--- a/results/ad_format/e2022m.txt
+++ b/results/ad_format/e2022m.txt
@@ -72,7 +72,7 @@ Keble III                   0   1   1   1
 University III              0  -1  -1   0
 Christ Church III          -1  -1   0   0
 Oriel III                   1   1   1   1
-Mansfield III              -1   0   0   0
+Mansfield II               -1   0   0   0
 Balliol III                 1   1   1   1
 Somerville II               0  -1  -1  -1
 Wolfson IV                 -1  -1  -1   0

--- a/results/ad_format/e2022w.txt
+++ b/results/ad_format/e2022w.txt
@@ -71,7 +71,7 @@ Oriel III                  -1  -1  -1  -1
 St Antony's II              1   1   1  -1
 St Hilda's II              -3  -1  -1  -1
 Exeter II                  -1   0  -1  -1
-Chirst Church III           1   0   1   1
+Christ Church III           1   0   1   1
 St Benet's Hall             3   1   1   2
 University III              0   1   1   1
 Merton II                   0  -1   0   1

--- a/results/ad_format/l2023m.txt
+++ b/results/ad_format/l2023m.txt
@@ -46,7 +46,7 @@ St Catharine's II          -1  -3   0   0
 Fitzwilliam II              1   1   0   0
 LMBC III                    0  -1   0   0
 Peterhouse II              -1   3   0   0
-Clare Hall II               1   1   0   0
+Clare Hall                  1   1   0   0
 Churchill II                0  -1   0   0
 Selwyn II                  -1   0   0   0
 Lucy Cavendish              1   1   0   0

--- a/results/ad_format/t1969m.txt
+++ b/results/ad_format/t1969m.txt
@@ -51,7 +51,7 @@ Exeter II                   1  -1   1  -1
 Magdalen II                -6  -2   0   0
 Wadham II                   1   2   2   2
 University III              1  -1  -1   0
-Merton III                 -1  -1   0   0
+Merton II                  -1  -1   0   0
 Jesus II                   -3   1  -1   0
 Osler House                 3   1   2   2
 Keble III                  -2   1   1   0


### PR DESCRIPTION
Found four ad_format files that need crew name changes to match bumps charts. Here are the changes and the information used that supports this change:

* Eights 2022 Men: Mansfield 3 -> Mansfield 2 (http://eodg.atm.ox.ac.uk/user/dudhia/rowing/eights/e22fin.html)
* Eights 2022 Women: Chirst Church 3 -> Christ Church 3 (http://eodg.atm.ox.ac.uk/user/dudhia/rowing/eights/e22fin.html)
* Lents 2023 Men: Clare Hall 2 - Clare Hall (http://www.cucbc.org/bumps/results/26/1)
* Torpids 1969 Men: Merton 3 -> Merton 2 (https://eodg.atm.ox.ac.uk/user/dudhia/rowing/bumps/t1969/)